### PR TITLE
Change Int to Int32 in DatabaseType array documentation

### DIFF
--- a/Sources/DuckDB/DatabaseType.swift
+++ b/Sources/DuckDB/DatabaseType.swift
@@ -32,7 +32,7 @@
 /// only contain ``DatabaseType/integer`` values.
 ///
 /// DuckDB also supports columns of composite types. For example, it is possible
-/// to define an array of integers (`INT[]`), which can be cast to `[Int]`
+/// to define an array of integers (`INT[]`), which can be cast to `[Int32]`
 /// within Swift using ``Column/cast(to:)-4376d``. It is also possible to
 /// define database types as arbitrary structs (`ROW(i INTEGER, j VARCHAR)`),
 /// which can be cast to their `Decodable` matching Swift type in the same way.


### PR DESCRIPTION
The example mentioned, casting to `[Int]` does not actually work because `Int` is not a type that is supported by `VectorElementDataDecoder.SingleValueContainer`. Doing so causes an infinite loop inside `VectorElementDataDecoder` as it tries to decode an unsupported type. Here's a minimal repro for that issue:

```swift
let connection = try Database(store: .inMemory).connect()
try connection.execute("""
  CREATE TABLE list_table (int_list INT[]);
  INSERT INTO list_table VALUES ([1, NULL, 3]);
""")
let results = try connection.query("SELECT * FROM list_table");
print(results[0].cast(to: [Int?].self)[0] ?? [])
```

For now, this PR fixes the docs so the example described works. There should then be an additional change to either:

a) Add `Int`/`UInt` as supported types (mapping to either `Int32`/`Int64` based on the platform)
b) Throw an immediate error on an unsupported type without going into the infinite decoding loop

I'm also happy to make one of these two changes, let me know which one you'd prefer.