### PR TITLE
Remove `isFileURL` check in `Database` constructor

### DIFF
--- a/Sources/DuckDB/Database.swift
+++ b/Sources/DuckDB/Database.swift
@@ -80,15 +80,11 @@ public final class Database: Sendable {
   public convenience init(
     store: Store = .inMemory, configuration: Configuration? = nil
   ) throws {
-    var fileURL: URL?
-    if case .file(let url) = store {
-      guard url.isFileURL else {
-        throw DatabaseError.databaseFailedToInitialize(
-          reason: "provided URL for database store file must be local")
-      }
-      fileURL = url
-    }
-    try self.init(path: fileURL?.path, config: configuration)
+    let path: String? = {
+        guard case .file(let url) = store else { return nil }
+        return url.path
+    }()
+    try self.init(path: path, config: configuration)
   }
   
   private init(path: String?, config: Configuration?) throws {


### PR DESCRIPTION
The path argument for `Database::init` should allow paths other than the ones starting with "file:" to support DuckDB's storage extensions.
Fixes https://github.com/duckdb/duckdb-swift/issues/14.