### PR TITLE
ResultSet row access performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+.DS_Store
+/.build
+/.swiftpm
+/.devContainer
+/Packages
+/*.xcodeproj
+xcuserdata/
+/.vscode/*
+.env.*
+.env
+.dockerignore
+Package.resolved
+

--- a/Tests/DuckDBTests/ResultSetRowIteratorTests.swift
+++ b/Tests/DuckDBTests/ResultSetRowIteratorTests.swift
@@ -1,0 +1,115 @@
+//
+//  DuckDB
+//  https://github.com/duckdb/duckdb-swift
+//
+//  Copyright © 2018-2025 Stichting DuckDB Foundation
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+
+import Foundation
+import XCTest
+@testable import DuckDB
+
+// MARK: - ResultSetRowIteratorTests
+
+final class ResultSetRowIteratorTests: XCTestCase {
+  func test_forEachRow_countsAllRows() throws {
+    let db = try Database(store: .inMemory)
+    let conn = try db.connect()
+    // Insert 10 rows
+    try conn.execute("CREATE TABLE t(a INTEGER);")
+    for i in 0..<10 {
+      try conn.execute("INSERT INTO t VALUES (\(i));")
+    }
+    let result = try conn.query("SELECT * FROM t;")
+    var count = 0
+    result.forEachRow { _ in
+      count += 1
+    }
+    XCTAssertEqual(count, Int(result.rowCount))
+  }
+  
+  func test_forEachRow_matchesElementAccess() throws {
+    let db = try Database(store: .inMemory)
+    let conn = try db.connect()
+    // Insert 5 rows
+    try conn.execute("CREATE TABLE t(a INTEGER, b VARCHAR);")
+    let values: [(Int, String)] = [(1, "one"), (2, "two"), (3, "three"), (4, "four"), (5, "five")]
+    for (a, b) in values {
+      try conn.execute("INSERT INTO t VALUES (\(a), '\(b)');")
+    }
+    let result = try conn.query("SELECT * FROM t ORDER BY a;")
+    let intCol = result[0].cast(to: Int32.self)
+    let strCol = result[1].cast(to: String.self)
+    var rowIndex = 0
+    result.forEachRow { row in
+      // Compare values via RowCursor and via element(forColumn:at:)
+      let aVal = intCol[DBInt(row.rowInChunk)]
+      let bVal = strCol[DBInt(row.rowInChunk)]
+      let aEl = intCol[DBInt(rowIndex)]
+      let bEl = strCol[DBInt(rowIndex)]
+      XCTAssertEqual(aVal, aEl)
+      XCTAssertEqual(bVal, bEl)
+      rowIndex += 1
+    }
+    XCTAssertEqual(rowIndex, Int(result.rowCount))
+  }
+  
+  func test_forEachRow_emptyResult() throws {
+    let db = try Database(store: .inMemory)
+    let conn = try db.connect()
+    try conn.execute("CREATE TABLE t(a INTEGER);")
+    let result = try conn.query("SELECT * FROM t WHERE 1=0;")
+    var called = false
+    result.forEachRow { _ in
+      called = true
+    }
+    XCTAssertFalse(called)
+    XCTAssertEqual(result.rowCount, 0)
+  }
+  
+  func test_forEachRow_multipleColumns() throws {
+    let db = try Database(store: .inMemory)
+    let conn = try db.connect()
+    try conn.execute("CREATE TABLE t(i INT, f DOUBLE, s VARCHAR);")
+    try conn.execute("INSERT INTO t VALUES (1, 3.14, 'duck');")
+    try conn.execute("INSERT INTO t VALUES (2, -2.71, NULL);")
+    let result = try conn.query("SELECT * FROM t ORDER BY i;")
+    let intCol = result[0].cast(to: Int32.self)
+    let doubleCol = result[1].cast(to: Double.self)
+    let strCol = result[2].cast(to: String.self)
+    var rows: [[Any?]] = []
+    result.forEachRow { row in
+      let i = intCol[DBInt(row.rowInChunk)]
+      let f = doubleCol[DBInt(row.rowInChunk)]
+      let s = strCol[DBInt(row.rowInChunk)]
+      rows.append([i, f, s])
+    }
+    XCTAssertEqual(rows.count, 2)
+    // Compare with element(forColumn:at:)
+    for idx in 0..<result.rowCount {
+      let i = intCol[DBInt(idx)]
+      let f = doubleCol[DBInt(idx)]
+      let s = strCol[DBInt(idx)]
+      XCTAssertEqual(rows[Int(idx)][0] as? Int32, i)
+      XCTAssertEqual(rows[Int(idx)][1] as? Double, f)
+      XCTAssertEqual(rows[Int(idx)][2] as? String, s)
+    }
+  }
+}


### PR DESCRIPTION
When accessing rows from a ResultSet, the old implementation of 
`element(forColumn:at:)`
performed a linear scan over all chunks to locate the chunk containing the requested row.

- For each rowIndex, iteration started from chunk 0 and walked forward until it found the correct chunk.
- With results chunked (e.g., ~10k rows per chunk), this made each successive 10k rows slower to fetch, resulting in quadratic complexity (O(N × #chunks)) instead of linear.
- In practice, queries reading large Parquet files slowed down dramatically as the row count increased.

The PR proposes a solution that replaces the linear scan with a cached binary search design inside `ChunkStorage.chunkInfo(forRow:)`

### Row Offsets Precomputation

- Build a rowOffsets array of length `chunkCount + 1`, where each entry is the cumulative row count up to that chunk.
- This lets us represent each chunk’s global row range as `rowOffsets[j] ..< rowOffsets[j+1]`.

### Cache Fast-path

- Store the last (chunkIndex, range) used.
- If the next requested row index falls in this range, we can answer in O(1).
- Sequential scans (the common case) almost always hit this fast path.

### Upper-bound Binary Search

- If the cache misses, use a binary search on rowOffsets to find the correct chunk in O(log #chunks).
- This avoids the previous linear walk through chunks.
- The search is safe and exact — no “fallback to last chunk” logic anymore. Out-of-bounds indices now trigger a clear precondition failure.

### Row Iterator (forEachRow)

- Added a row-level iteration API with RowCursor.
- This iterates chunk-by-chunk and row-by-row without repeatedly calculating global indices.
- Provides a clean, ergonomic, and efficient way to walk rows sequentially.

### Benefits

- Performance: Sequential row access is now O(N) with only a tiny cost at chunk boundaries. Random access is O(log #chunks) instead of O(#chunks).
- Ergonomics: forEachRow provides a more natural iteration style and avoids common pitfalls like mixing global vs chunk-local indices.
