### PR TITLE
Make columnDataType(at:) and columnLogicalType(at:) public on ResultSet

### DIFF
--- a/Sources/DuckDB/ResultSet.swift
+++ b/Sources/DuckDB/ResultSet.swift
@@ -98,11 +98,19 @@ public struct ResultSet: Sendable {
     return nil
   }
   
-  func columnDataType(at index: DBInt) -> DatabaseType {
+  /// The underlying database type for the given column index
+  ///
+  /// - Parameter index: the index of the column in the result set
+  /// - Returns: the database type of the column
+  public func columnDataType(at index: DBInt) -> DatabaseType {
     storage.columnDataType(at: index)
   }
 
-  func columnLogicalType(at index: DBInt) -> LogicalType {
+  /// The underlying logical type for the given column index
+  ///
+  /// - Parameter index: the index of the column in the result set
+  /// - Returns: the logical type of the column
+  public func columnLogicalType(at index: DBInt) -> LogicalType {
     storage.columnLogicalType(at: index)
   }
   

--- a/Sources/DuckDB/ResultSet.swift
+++ b/Sources/DuckDB/ResultSet.swift
@@ -98,18 +98,10 @@ public struct ResultSet: Sendable {
     return nil
   }
   
-  /// The underlying database type for the given column index
-  ///
-  /// - Parameter index: the index of the column in the result set
-  /// - Returns: the database type of the column
   public func columnDataType(at index: DBInt) -> DatabaseType {
     storage.columnDataType(at: index)
   }
 
-  /// The underlying logical type for the given column index
-  ///
-  /// - Parameter index: the index of the column in the result set
-  /// - Returns: the logical type of the column
   public func columnLogicalType(at index: DBInt) -> LogicalType {
     storage.columnLogicalType(at: index)
   }


### PR DESCRIPTION
These two methods on `ResultSet` are currently internal but useful for external consumers that need column type metadata without going through a `Column` wrapper.

Use case: building column metadata arrays (name + type) from a `ResultSet` in a single pass, which is common in database GUI clients and tooling.

No behavioral changes — only access level promotion from `internal` to `public`.